### PR TITLE
refactor: memos controller & view

### DIFF
--- a/app/controllers/memos_controller.rb
+++ b/app/controllers/memos_controller.rb
@@ -1,14 +1,8 @@
 class MemosController < ApplicationController
   before_action :authenticate_user!
-  before_action :set_memo, only: %i[update]
 
   def create
-    @memo = Memo.new(memo_params.merge(user_id: current_user.id))
-
-    Rails.logger.info "Received memo params: #{memo_params.inspect}"
-    Rails.logger.info "Memo object before save: #{@memo.inspect}"
-    puts params.inspect
-
+    @memo = current_user.memos.new(memo_params)
     if @memo.save
       render json: { message: "保存しました。", memo: @memo }
     else
@@ -17,18 +11,15 @@ class MemosController < ApplicationController
   end
 
   def update
+    @memo = current_user.memos.find_by(id: params[:id])
     if @memo.update(memo_params)
-      render json: { message: "更新しました。", memo: @memo }
+      render json: { message: "保存しました。", memo: @memo }
     else
-      render json: { message: "更新に失敗しました。", errors: @memo.errors.full_messages }, status: :unprocessable_entity
+      render json: { message: "保存に失敗しました。", errors: @memo.errors.full_messages }, status: :unprocessable_entity
     end
   end
 
   private
-
-  def set_memo
-    @memo = Memo.find_by(id: params[:id], user_id: current_user.id)
-  end
 
   def memo_params
     params.require(:memo).permit(:age_group, :content)

--- a/app/javascript/controllers/index.js
+++ b/app/javascript/controllers/index.js
@@ -6,3 +6,7 @@ import { application } from "./application"
 
 import HelloController from "./hello_controller"
 application.register("hello", HelloController)
+
+// memo関連
+import MemoController from "./memo_controller";
+application.register("memo", MemoController);

--- a/app/javascript/controllers/memo_controller.js
+++ b/app/javascript/controllers/memo_controller.js
@@ -1,0 +1,66 @@
+import { Controller } from "@hotwired/stimulus";
+
+// Stimulusコントローラーを定義
+export default class extends Controller {
+  static targets = ["textarea", "button"];
+
+  connect() {
+    // Turboによる遷移後に動作することを保証
+    console.log("MemoController connected!");
+
+    this.buttonTarget.addEventListener("click", () => this.toggleEdit());
+  }
+
+  toggleEdit() {
+    const button = this.buttonTarget;
+    const textarea = this.textareaTarget;
+
+    if (button.dataset.action === "save") {
+      this.saveMemo(textarea, button);
+    } else {
+      this.enableEditing(textarea, button);
+    }
+  }
+
+  enableEditing(textarea, button) {
+    button.dataset.action = "save";
+    button.textContent = "保存";
+    textarea.removeAttribute("readonly");
+    button.classList.replace("btn-outline-secondary", "btn-outline-primary");
+  }
+
+  saveMemo(textarea, button) {
+    const csrfToken = document.querySelector('meta[name="csrf-token"]').content;
+    const ageGroup = textarea.dataset.ageGroup;
+    const memoId = textarea.dataset.id; // 既存メモID
+
+    const url = memoId ? `/memos/${memoId}` : "/memos"; // PATCHかPOSTのURLを決定
+    const method = memoId ? "PATCH" : "POST"; // HTTPメソッドを切り替え
+
+    fetch(url, {
+      method: method,
+      headers: {
+        "Content-Type": "application/json",
+        "X-CSRF-Token": csrfToken
+      },
+      body: JSON.stringify({
+        memo: {
+          content: textarea.value,
+          age_group: parseInt(ageGroup)
+        }
+      })
+    })
+      .then(response => response.json())
+      .then(data => {
+        if (data.memo) {
+          textarea.dataset.id = data.memo.id;
+          button.dataset.action = "edit";
+          button.textContent = "編集";
+          textarea.setAttribute("readonly", true);
+          button.classList.replace("btn-outline-primary", "btn-outline-secondary");
+        } else {
+          alert(data.message || "保存に失敗しました。");
+        }
+      });
+  }
+}

--- a/app/views/life_events/index.html.erb
+++ b/app/views/life_events/index.html.erb
@@ -6,7 +6,6 @@
     <h4 class="mb-3">プランの具体化</h4>
     <p>今後の計画や目標などをメモに整理しましょう。</p>
   </div>
-
   <% @age_groups_to_display.each do |age_group| %>
     <div class="card mb-3">
       <div class="card-body">
@@ -31,91 +30,18 @@
           </div>
           <div class="col mt-2 mt-md-0">
             <% first_memo = @memos[age_group]&.first %>
-            <div id="memo-container-<%= age_group %>">
-              <textarea id="memo-content-<%= age_group %>" rows="2" class="form-control" data-age-group="<%= age_group %>" data-id="<%= first_memo&.id %>" <%= first_memo&.content.present? ? 'readonly' : '' %>><%= first_memo&.content.present? ? first_memo.content : '' %></textarea>
-              <button
-                id="memo-button-<%= age_group %>"
-                class="btn <%= first_memo&.content.present? ? 'btn-outline-secondary' : 'btn-outline-primary' %> btn-sm mt-2"
-                data-action="<%= first_memo&.content.present? ? 'edit' : 'save' %>">
-                  <%= first_memo&.content.present? ? '編集' : '保存' %>
-              </button>
-            </div>
+            <%= render "memos/memo", age_group: age_group, first_memo: first_memo %>
           </div>
         </div>
       </div>
     </div>
   <% end %>
-
   <div class="d-flex justify-content-center">
     <% if @grouped_life_events.empty? %>
       <%= link_to '情報入力画面へ', incomes_path, class: 'btn btn-primary me-2', data: { turbo: true } %>
     <% else %>
-      <div class="d-flex justify-content-center">
-        <%= link_to 'ライフイベント編集', new_life_event_path, class: 'btn btn-outline-secondary me-2', data: { turbo: true } %>
-        <%= link_to 'ホームに戻る', dashboard_index_path, class: 'btn btn-primary me-2', data: { turbo: true } %>
-      </div>
+      <%= link_to 'ライフイベント編集', new_life_event_path, class: 'btn btn-outline-secondary me-2', data: { turbo: true } %>
+      <%= link_to 'ホームに戻る', dashboard_index_path, class: 'btn btn-primary me-2', data: { turbo: true } %>
     <% end %>
   </div>
 </div>
-
-<script>
-  document.addEventListener("turbo:load", () => {
-    const memoContainers = document.querySelectorAll("[id^=memo-container-]");
-
-    memoContainers.forEach(container => {
-      // ボタンとテキストエリアを取得
-      const button = container.querySelector("button");
-      const textarea = container.querySelector("textarea");
-
-      // 重複防止のため既存のイベントリスナーを削除
-      const newButton = button.cloneNode(true);
-      button.replaceWith(newButton);
-
-      // イベントリスナーを登録
-      newButton.addEventListener("click", () => {
-        if (newButton.dataset.action === "save") {
-          // 保存処理
-          const csrfToken = document.querySelector('meta[name="csrf-token"]').content;
-          const ageGroup = textarea.dataset.ageGroup;
-          const memoId = textarea.dataset.id; // 既存メモID
-
-          const url = memoId ? `/memos/${memoId}` : "/memos"; // PATCHかPOSTのURLを決定
-          const method = memoId ? "PATCH" : "POST"; // HTTPメソッドを切り替え
-
-          fetch(url, {
-            method: method,
-            headers: {
-              "Content-Type": "application/json",
-              "X-CSRF-Token": csrfToken
-            },
-            body: JSON.stringify({
-              memo: {
-                content: textarea.value,
-                age_group: parseInt(ageGroup)
-              }
-            })
-          })
-            .then(response => response.json())
-            .then(data => {
-              if (data.memo) {
-                // 保存成功後に状態を更新
-                textarea.dataset.id = data.memo.id; // 新しいIDを設定
-                newButton.dataset.action = "edit";
-                newButton.textContent = "編集";
-                textarea.setAttribute("readonly", true);
-                newButton.classList.replace("btn-outline-primary", "btn-outline-secondary");
-              } else {
-                alert(data.message || "保存に失敗しました。");
-              }
-            });
-        } else {
-          // 編集モードに切り替える
-          newButton.dataset.action = "save";
-          newButton.textContent = "保存";
-          textarea.removeAttribute("readonly");
-          newButton.classList.replace("btn-outline-secondary", "btn-outline-primary");
-        }
-      });
-    });
-  });
-</script>

--- a/app/views/memos/_memo.html.erb
+++ b/app/views/memos/_memo.html.erb
@@ -1,0 +1,12 @@
+<div id="memo-container-<%= age_group %>" data-controller="memo">
+  <textarea id="memo-content-<%= age_group %>" rows="2" class="form-control" data-memo-target="textarea" data-age-group="<%= age_group %>" data-id="<%= first_memo&.id %>" <%= first_memo&.content.present? ? 'readonly' : '' %>><%= first_memo&.content.present? ? first_memo.content : '' %></textarea>
+  <button 
+    id="memo-button-<%= age_group %>"
+    class="btn <%= first_memo&.content.present? ? 'btn-outline-secondary' : 'btn-outline-primary' %> btn-sm mt-2"
+    data-memo-target="button"
+    data-action="click->memo#toggleEdit"
+    data-action="<%= first_memo&.content.present? ? 'edit' : 'save' %>"
+  >
+    <%= first_memo&.content.present? ? '編集' : '保存' %>
+  </button>
+</div>


### PR DESCRIPTION
◼︎memos関連のリファクタリング
　controller
　・データをcurrent_userから直接取得し、user_idのparamsへのmerge部分を削除
　・ログ出力部分削除
　・メッセージの統一
　view
　・life_events/index内に記述していた、メモ表示をapp/views/memo/内のパーシャルに切り離し
　・d-flex justify-content-centerの重複箇所を削除
　・life_events/index内に記述していた、javascriptの記述をjsファイルに切り離し
　